### PR TITLE
Timestep based mappers

### DIFF
--- a/environments/launchers.py
+++ b/environments/launchers.py
@@ -259,6 +259,7 @@ def mountain_car_ppo(state_path,
     min_lr = 0.0001
 
     lr_dec = LinearStepMapper(
+        step_type    = "iteration",
         steps        = [200,],
         step_values  = [0.0003,],
         ending_value = 0.0001)
@@ -713,16 +714,19 @@ def bipedal_walker_hardcore_ppo(state_path,
     # scores of 320+ over 100 test runs.
     #
     lr_dec = LinearStepMapper(
+        step_type    = "iteration",
         steps        = [3900,],
         step_values  = [0.0001,],
         ending_value = 0.00001)
 
     reward_clip_min = LinearStepMapper(
+        step_type    = "iteration",
         steps        = [4000,],
         step_values  = [-1.,],
         ending_value = -10.)
 
     bs_clip_min = LinearStepMapper(
+        step_type    = "iteration",
         steps        = [4000,],
         step_values  = [-1.,],
         ending_value = -10.)
@@ -1314,6 +1318,7 @@ def hopper_ppo(state_path,
     min_lr = 0.0001
 
     lr_dec = LinearStepMapper(
+        step_type    = "iteration",
         steps        = [400,],
         step_values  = [0.0003,],
         ending_value = 0.0001)
@@ -1493,7 +1498,7 @@ def robot_warehouse_tiny(
     min_lr = 0.00001
 
     lr_dec = LinearDecrementer(
-        max_iteration = 4000,
+        max_timestep  = 40000000,
         max_value     = lr,
         min_value     = min_lr)
 
@@ -1501,7 +1506,7 @@ def robot_warehouse_tiny(
     min_entropy_weight = 0.01
 
     entropy_dec = LinearDecrementer(
-        max_iteration = 4000,
+        max_timestep  = 40000000,
         max_value     = entropy_weight,
         min_value     = min_entropy_weight)
     #

--- a/environments/launchers.py
+++ b/environments/launchers.py
@@ -28,7 +28,7 @@ def run_ppo(env_generator,
             envs_per_proc       = 1,
             icm_network         = ICM,
             batch_size          = 256,
-            ts_per_rollout      = 1024,
+            ts_per_rollout      = num_procs * 1024,
             epochs_per_iter     = 10,
             target_kl           = 100.,
             lr                  = 3e-4,
@@ -155,12 +155,15 @@ def cartpole_ppo(state_path,
         max_value      = lr,
         min_value      = min_lr)
 
+    ts_per_rollout = num_procs * 256
+
     run_ppo(env_generator      = env_generator,
             random_seed        = random_seed,
             batch_size         = 256,
             actor_kw_args      = actor_kw_args,
             critic_kw_args     = critic_kw_args,
             ac_network         = FeedForwardNetwork,
+            ts_per_rollout     = ts_per_rollout,
             max_ts_per_ep      = 32,
             use_gae            = True,
             normalize_obs      = True,
@@ -210,12 +213,15 @@ def pendulum_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator      = env_generator,
             random_seed        = random_seed,
             ac_network         = FeedForwardNetwork,
             actor_kw_args      = actor_kw_args,
             critic_kw_args     = critic_kw_args,
             max_ts_per_ep      = 32,
+            ts_per_rollout     = ts_per_rollout,
             use_gae            = True,
             normalize_obs      = True,
             normalize_rewards  = True,
@@ -281,7 +287,6 @@ def mountain_car_ppo(state_path,
             critic_kw_args     = critic_kw_args,
             dynamic_bs_clip    = True,
             max_ts_per_ep      = 200,
-            ts_per_rollout     = 2048,
             ext_reward_weight  = 1./100.,
             lr_dec             = lr_dec,
             lr                 = lr,
@@ -345,7 +350,6 @@ def mountain_car_continuous_ppo(state_path,
             random_seed        = random_seed,
             ac_network         = FeedForwardNetwork,
             max_ts_per_ep      = 128,
-            ts_per_rollout     = 2048,
             batch_size         = 512,
             lr_dec             = lr_dec,
             lr                 = lr,
@@ -402,11 +406,13 @@ def acrobot_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator      = env_generator,
             random_seed        = random_seed,
             ac_network         = FeedForwardNetwork,
             max_ts_per_ep      = 32,
-            ts_per_rollout     = 1024,
+            ts_per_rollout     = ts_per_rollout,
             lr_dec             = lr_dec,
             lr                 = lr,
             min_lr             = min_lr,
@@ -627,6 +633,8 @@ def bipedal_walker_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     #
     # Thresholding the reward to a low of -1 doesn't drastically
     # change learning, but it does help a bit. Clipping the bootstrap
@@ -639,7 +647,7 @@ def bipedal_walker_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 32,
-            ts_per_rollout      = 1024,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_adv       = True,
             normalize_obs       = True,
@@ -731,6 +739,8 @@ def bipedal_walker_hardcore_ppo(state_path,
         step_values  = [-1.,],
         ending_value = -10.)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
@@ -738,7 +748,7 @@ def bipedal_walker_hardcore_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 32,
-            ts_per_rollout      = 2048,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -812,13 +822,15 @@ def breakout_pixels_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator        = wrapper_generator,
             random_seed          = random_seed,
             ac_network           = AtariPixelNetwork,
             actor_kw_args        = actor_kw_args,
             critic_kw_args       = critic_kw_args,
             batch_size           = 512,
-            ts_per_rollout       = 2048,
+            ts_per_rollout       = ts_per_rollout,
             max_ts_per_ep        = 64,
             epochs_per_iter      = 30,
             reward_clip          = (-1., 1.),
@@ -889,13 +901,15 @@ def breakout_ram_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator      = wrapper_generator,
             random_seed        = random_seed,
             ac_network         = FeedForwardNetwork,
             actor_kw_args      = actor_kw_args,
             critic_kw_args     = critic_kw_args,
             batch_size         = 512,
-            ts_per_rollout     = 2048,
+            ts_per_rollout     = ts_per_rollout,
             max_ts_per_ep      = 64,
             use_gae            = True,
             epochs_per_iter    = 30,
@@ -934,11 +948,14 @@ def inverted_pendulum_ppo(state_path,
 
     env_generator = lambda : gym.make('InvertedPendulum-v2')
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
             use_gae             = True,
             use_icm             = False,
+            ts_per_rollout      = ts_per_rollout,
             state_path          = state_path,
             load_state          = load_state,
             render              = render,
@@ -986,6 +1003,8 @@ def inverted_double_pendulum_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
@@ -993,7 +1012,7 @@ def inverted_double_pendulum_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 16,
-            ts_per_rollout      = 1024,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1049,6 +1068,8 @@ def ant_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
@@ -1056,7 +1077,7 @@ def ant_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 64,
-            ts_per_rollout      = 2048,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1135,6 +1156,8 @@ def humanoid_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
@@ -1142,7 +1165,7 @@ def humanoid_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 16,
-            ts_per_rollout      = 1024,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1206,6 +1229,8 @@ def humanoid_stand_up_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
@@ -1213,7 +1238,7 @@ def humanoid_stand_up_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 32,
-            ts_per_rollout      = 1024,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1261,6 +1286,8 @@ def walker2d_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 1024
+
     #
     # arXiv:2006.05990v1 suggests that value normalization significantly hurts
     # performance in walker2d. I also find this to be the case.
@@ -1272,7 +1299,7 @@ def walker2d_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 16,
-            ts_per_rollout      = 2048,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1323,6 +1350,8 @@ def hopper_ppo(state_path,
         step_values  = [0.0003,],
         ending_value = 0.0001)
 
+    ts_per_rollout = num_procs * 1024
+
     #
     # I find that value normalization hurts the hopper environment training.
     # That may be a result of it's combination with other settings in here.
@@ -1334,7 +1363,7 @@ def hopper_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 16,
-            ts_per_rollout      = 2048,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1384,6 +1413,8 @@ def half_cheetah_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 512
+
     #
     # Normalizing values seems to stabilize results in this env.
     #
@@ -1394,7 +1425,7 @@ def half_cheetah_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 32,
-            ts_per_rollout      = 1024,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1442,6 +1473,8 @@ def swimmer_ppo(state_path,
         max_value     = lr,
         min_value     = min_lr)
 
+    ts_per_rollout = num_procs * 1024
+
     run_ppo(env_generator       = env_generator,
             random_seed         = random_seed,
             ac_network          = FeedForwardNetwork,
@@ -1449,7 +1482,7 @@ def swimmer_ppo(state_path,
             critic_kw_args      = critic_kw_args,
             batch_size          = 512,
             max_ts_per_ep       = 32,
-            ts_per_rollout      = 2048,
+            ts_per_rollout      = ts_per_rollout,
             use_gae             = True,
             normalize_obs       = True,
             normalize_rewards   = True,
@@ -1515,7 +1548,7 @@ def robot_warehouse_tiny(
     # the number of agents. We want each rank to see ~2 episodes =>
     # num_ranks * 2 * 512.
     #
-    ts_per_rollout = comm.size * 2 * 512
+    ts_per_rollout = num_procs * 2 * 512
 
     #
     # This environment comes from arXiv:2006.07869v4.
@@ -1606,7 +1639,7 @@ def robot_warehouse_small(
     # the number of agents. We want each rank to see ~4 episodes =>
     # num_ranks * 4 * 512.
     #
-    ts_per_rollout = comm.size * 4 * 512
+    ts_per_rollout = num_procs * 4 * 512
 
     #
     # This is a very sparse reward environment, and there are series of

--- a/ppo.py
+++ b/ppo.py
@@ -763,7 +763,8 @@ class PPO(object):
         rank_print("--------------------------------------------------------")
 
     def update_learning_rate(self,
-                             iteration):
+                             iteration,
+                             timestep):
         """
             Update the learning rate. This relies on the lr_dec function,
             which expects an iteration and returns an updated learning rate.
@@ -772,7 +773,9 @@ class PPO(object):
                 iteration    The current iteration of training.
         """
 
-        self.lr = self.lr_dec(iteration)
+        self.lr = self.lr_dec(
+            iteration = iteration,
+            timestep  = timestep)
 
         update_optimizer_lr(self.actor_optim, self.lr)
         update_optimizer_lr(self.critic_optim, self.lr)
@@ -783,7 +786,8 @@ class PPO(object):
         self.status_dict["lr"] = self.actor_optim.param_groups[0]["lr"]
 
     def update_entropy_weight(self,
-                              iteration):
+                              iteration,
+                              timestep):
         """
             Update the entropy weight. This relies on the entropy_dec function,
             which expects an iteration and returns an updated entropy weight.
@@ -791,7 +795,10 @@ class PPO(object):
             Arguments:
                 iteration    The current iteration of training.
         """
-        self.entropy_weight = self.entropy_dec(iteration)
+        self.entropy_weight = self.entropy_dec(
+            iteration = iteration,
+            timestep  = timestep)
+
         self.status_dict["entropy weight"] = self.entropy_weight
 
     def get_intrinsic_reward(self,
@@ -1496,8 +1503,13 @@ class PPO(object):
 
             self.status_dict["iteration"] += 1
 
-            self.update_learning_rate(self.status_dict["iteration"])
-            self.update_entropy_weight(self.status_dict["iteration"])
+            self.update_learning_rate(
+                self.status_dict["iteration"],
+                self.status_dict["timesteps"])
+
+            self.update_entropy_weight(
+                self.status_dict["iteration"],
+                self.status_dict["timesteps"])
 
             data_loader = DataLoader(
                 dataset,

--- a/utils/iteration_mappers.py
+++ b/utils/iteration_mappers.py
@@ -6,79 +6,143 @@ comm      = MPI.COMM_WORLD
 rank      = comm.Get_rank()
 num_procs = comm.Get_size()
 
-class IterationMapper(object):
+class StepMapper(object):
 
-    def __call__(self, value, iteration, **kw_args):
+    def __init__(self,
+                 max_iteration = None,
+                 max_timestep  = None):
+
+        if max_iteration == None and max_timestep == None:
+            msg  = "ERROR: the chosen step mapper requires that one of "
+            msg += "the following options are set: max_iteration, max_timestep."
+            rank_print(msg)
+            comm.Abort()
+
+        elif max_iteration != None and max_timestep != None:
+            msg  = "ERROR: the chosen step mapper requires that either "
+            msg += "max_iteration or max_timestep are set, but not both."
+            rank_print(msg)
+            comm.Abort()
+
+        self.max_iteration = max_iteration
+        self.max_timestep  = max_timestep
+        self.step_type     = ""
+
+        if max_iteration != None:
+            self.step_type = "iteration"
+            self.max_step = max_iteration
+
+        elif max_timestep != None:
+            self.step_type = "timestep"
+            self.max_step = max_timestep
+
+    def _get_step(self,
+                  iteration,
+                  timestep):
+
+        if self.step_type == "iteration":
+            return iteration
+
+        if self.step_type == "timestep":
+            return timestep
+
+        rank_print("ERROR: unkonwn step type {}".format(self.step_type))
+
+    def __call__(self, iteration, timestep, **kw_args):
         raise NotImplementedError
 
 
-class LogDecrementer(IterationMapper):
+class LogDecrementer(StepMapper):
 
     def __init__(self,
-                 max_iteration,
                  max_value,
                  min_value,
+                 max_iteration = None,
+                 max_timestep  = None,
                  **kw_args):
+
+        super(LogDecrementer, self).__init__(
+            max_iteration = max_iteration,
+            max_timestep  = max_timestep,
+            **kw_args)
 
         self.min_value = min_value
         self.max_value = max_value
-        self.numerator = np.log(max_iteration) / (max_value - min_value)
+        self.numerator = np.log(self.max_step) / (max_value - min_value)
 
     def __call__(self,
-                  iteration,
-                  **kw_args):
+                 **kw_args):
 
-        dec_value = self.max_value - (np.log(iteration) / self.numerator)
+        step = self._get_step(**kw_args)
+
+        dec_value = self.max_value - (np.log(step) / self.numerator)
         dec_value = min(dec_value, self.max_value) 
         return max(dec_value, self.min_value)
 
 
-class LinearDecrementer(IterationMapper):
+class LinearDecrementer(StepMapper):
 
     def __init__(self,
-                 max_iteration,
                  max_value,
                  min_value,
+                 max_iteration = None,
+                 max_timestep  = None,
                  **kw_args):
+
+        super(LinearDecrementer, self).__init__(
+            max_iteration = max_iteration,
+            max_timestep  = max_timestep,
+            **kw_args)
 
         self.min_value     = min_value
         self.max_value     = max_value
-        self.max_iteration = max_iteration
 
     def __call__(self,
-                 iteration,
                  **kw_args):
 
-        frac = 1.0 - (iteration - 1.0) / self.max_iteration
+        step = self._get_step(**kw_args)
+
+        frac = 1.0 - (step - 1.0) / self.max_step
         new_val = min(self.max_value, frac * self.max_value)
         new_val = max(new_val, self.min_value)
         return new_val
 
 
-class LinearStepMapper(IterationMapper):
+class LinearStepMapper(StepMapper):
 
     def __init__(self,
                  steps,
                  step_values,
                  ending_value,
+                 step_type,
                  **kw_args):
         """
-            A class that maps iteration steps to values. Steps should
-            be a list containing iteration steps in ascending order. As long
-            as our iteration is < the current index of the step list (starting
+            A class that maps iterations or timeteps to values. Steps should
+            be a list containing iterations or timesteps in ascending order. As
+            long as our step is < the current index of the step list (starting
             at index 0), the associated value from step_values will be returned.
-            Once our iteration exceeds the current step, the index is
-            incremented, and the process repeats. If our iteration ever exceeds
+            Once our step exceeds the current step, the index is
+            incremented, and the process repeats. If our step ever exceeds
             the last step in steps, ending_value will be returned thereafter.
 
             Arguments:
-                steps         A list of iterations.
-                step_values   The values to corresponding to iterations below
-                              those in steps.
-                ending_value  The value to use if our iteration ever exceeds the
+                steps         A list of iterations or timesteps.
+                step_values   The values corresponding to steps.
+                ending_value  The value to use if our step ever exceeds the
                               last entry of steps.
+                step_type     A string determing which step type to use. Options
+                              are "iteration" and "timestep".
         """
 
+        avail_types = ["iteration", "timestep"]
+        if step_type not in avail_types:
+            msg  = "ERROR: received {} for step_type, ".format(step_type)
+            msg += "but step_type must be one of the "
+            msg += "following: {}".format(avail_types)
+            rank_print(msg)
+            comm.Abort()
+
+        self.step_type    = step_type
         self.steps        = steps
         self.step_values  = step_values
         self.ending_value = ending_value
@@ -96,13 +160,14 @@ class LinearStepMapper(IterationMapper):
             comm.Abort()
 
     def __call__(self,
-                 iteration,
                  **kw_args):
+
+        step = self._get_step(**kw_args)
 
         if self.range_idx >= len(self.steps):
             return self.ending_value
 
-        while iteration > self.steps[self.range_idx]:
+        while step > self.steps[self.range_idx]:
             self.range_idx += 1
 
             if self.range_idx >= len(self.steps):


### PR DESCRIPTION
Allow the step mappers to use timesteps instead of iterations when desired.

I also updated the ts_per_rollout to be based on the number of processors being used.