### PR TITLE
Copy rank saves

### DIFF
--- a/environments/env_wrappers.py
+++ b/environments/env_wrappers.py
@@ -518,12 +518,12 @@ class MultiAgentWrapper(IdentityWrapper):
             env_generator(),
             **kw_args)
 
-        self.need_agent_ids     = need_agent_ids
-        self.num_agents         = len(self.env.observation_space)
-        self.agent_ids          = np.arange(self.num_agents).reshape((-1, 1))
+        self.need_agent_ids = need_agent_ids
+        self.num_agents     = len(self.env.observation_space)
+        self.agent_ids      = np.arange(self.num_agents).reshape((-1, 1))
 
         if normalize_ids:
-            self.agent_ids /= self.num_agents
+            self.agent_ids = self.agent_ids / self.num_agents
 
         self.use_global_state   = use_global_state
         self.global_state_space = None

--- a/networks/ppo_networks.py
+++ b/networks/ppo_networks.py
@@ -47,7 +47,17 @@ class PPONetwork(nn.Module):
         else:
             f_name = "{}_{}.model".format(self.name, rank)
 
-        in_f   = os.path.join(path, f_name)
+        in_f = os.path.join(path, f_name)
+
+        #
+        # There are cases where we initially train using X ranks, and we
+        # later want to continue training using (X+k) ranks. In these cases,
+        # let's copy rank 0's network to all ranks > X.
+        #
+        if not os.path.exists(in_f):
+            f_name = "{}_0.model".format(self.name)
+            in_f   = os.path.join(path, f_name)
+
         self.load_state_dict(torch.load(in_f))
 
 

--- a/ppo.py
+++ b/ppo.py
@@ -1852,6 +1852,15 @@ class PPO(object):
 
         state_file = os.path.join(self.state_path, file_name)
 
+        #
+        # There are cases where we initially train using X ranks, and we
+        # later want to continue training using (X+k) ranks. In these cases,
+        # let's copy rank 0's info to all ranks > X.
+        #
+        if not os.path.exists(state_file):
+            file_name  = "state_0.pickle"
+            state_file = os.path.join(self.state_path, file_name)
+
         with open(state_file, "rb") as in_f:
             tmp_status_dict = pickle.load(in_f)
 

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -190,6 +190,15 @@ class RunningStatNormalizer(object):
 
         in_file = os.path.join(path, f_name)
 
+        #
+        # There are cases where we initially train using X ranks, and we
+        # later want to continue training using (X+k) ranks. In these cases,
+        # let's copy rank 0's info to all ranks > X.
+        #
+        if not os.path.exists(in_file):
+            f_name  = "{}_stats_0.pkl".format(self.name)
+            in_file = os.path.join(path, f_name)
+
         with open(in_file, "rb") as fh:
             self.running_stats = pickle.load(fh)
 


### PR DESCRIPTION
When we continue training from a previously saved state, we can now train using more processors than originally used. The extra processors will copy data from rank 0.